### PR TITLE
Fixed TypeError errors

### DIFF
--- a/import/Ubuntu/Content/ContentPeerPicker13.qml
+++ b/import/Ubuntu/Content/ContentPeerPicker13.qml
@@ -193,7 +193,8 @@ Item {
                 delegateWidth: units.gu(11)
                 delegateHeight: units.gu(11)
                 verticalSpacing: units.gu(2)
-                model: customPeerModelLoader ? customPeerModelLoader.item.peers : peerModelLoader.item.peers //This line give error "TypeError: Cannot read property 'peers' of null" > Move to onCompleted?
+                model: customPeerModelLoader ? customPeerModelLoader.item.peers
+                                             : peerModelLoader.item ? peerModelLoader.item.peers : null
                 delegate: peerDelegate
 
                 Label {

--- a/import/Ubuntu/Content/ResponsiveGridView.qml
+++ b/import/Ubuntu/Content/ResponsiveGridView.qml
@@ -56,7 +56,7 @@ Item {
         }
 
         onModelChanged: {
-            clip = parent.height != contentHeightForRows(Math.ceil(model.count / columns))
+            clip = model && parent.height != contentHeightForRows(Math.ceil(model.count / columns))
         }
 
         function pixelToGU(value) {


### PR DESCRIPTION
There are various `TypeError` errors that always shows when using content pickers.
One example is `TypeError: Cannot read property 'peers' of null`.
This fixes that and some other related `TypeError` errors.